### PR TITLE
fix typo of example code

### DIFF
--- a/ModulePatterns/index.html
+++ b/ModulePatterns/index.html
@@ -108,7 +108,7 @@
                     <pre><code data-trim contenteditable>
 &nbsp;
     // app.js
-    require('hello.js');
+    require('./hello.js');
 &nbsp;
                     </code></pre>
 <!--


### PR DESCRIPTION
fix example code : 
from
`require('hello.js');`
to
`require('./hello.js');`